### PR TITLE
feat: improve the pedestrian handler

### DIFF
--- a/src/config/config.development.yaml
+++ b/src/config/config.development.yaml
@@ -7,8 +7,8 @@ speed_modes:
     very_fast: 100
 
 object_detection:
-  model_path: "../../resources/models/best.pt"
-  min_confidence: 0.5
+  model_path: "../resources/models/best.pt"
+  min_confidence: 0.6
   image_size: 1280
   class_to_speed:
     5: 5

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,10 @@
 import can
+import logging
+import os
 
 from config import config
 from driving.can_controller import CANController
-from driving.speed_controller import SpeedController
+from driving.speed_controller import SpeedController, SpeedControllerState
 from object_recognition.handlers.pedestrian_handler import PedestrianHandler
 from object_recognition.handlers.speed_limit_handler import SpeedLimitHandler
 from object_recognition.handlers.traffic_light_handler import TrafficLightHandler
@@ -10,10 +12,23 @@ from object_recognition.object_controller import ObjectController
 from object_recognition.object_detector import ObjectDetector
 
 
+def initialize_can() -> can.Bus:
+    """Initialize the can bus."""
+    try:
+        os.system("ip link set can0 type can bitrate 500000")
+        os.system("ip link set can0 up")
+
+        return can.Bus(interface="socketcan", channel="can0", bitrate=500000)
+    except Exception:
+        logging.warning("Failed to initialize the CAN bus. Using the virtual CAN bus instead.")
+        return can.Bus(interface="virtual", channel="vcan0")
+
+
 if __name__ == "__main__":
-    can_bus = can.Bus(interface="virtual", channel="can0", bitrate=500000)
+    can_bus = initialize_can()
     can_controller = CANController(can_bus)
     speed_controller = SpeedController(can_controller)
+    speed_controller.state = SpeedControllerState.DRIVING
 
     controller = ObjectController(speed_controller)
     controller.add_handler(PedestrianHandler(controller))

--- a/src/object_recognition/handlers/traffic_light_handler.py
+++ b/src/object_recognition/handlers/traffic_light_handler.py
@@ -8,6 +8,8 @@ from ultralytics.engine.results import Boxes
 class TrafficLightHandler(BaseObjectHandler):
     """A handler for the traffic lights."""
 
+    stopped: bool = False
+
     def __init__(self, controller: ObjectController) -> None:
         """Initializes the traffic light handler.
 
@@ -20,14 +22,19 @@ class TrafficLightHandler(BaseObjectHandler):
 
         :param predictions: The detected traffic light.
         """
+        if self.controller.has_stopped() and not self.stopped:
+            return
+
         closest_class = self.get_closest_prediction(predictions)
         if closest_class is None:
             return
 
         match closest_class:
             case Label.TRAFFIC_LIGHT_RED:
+                self.stopped = True
                 self.controller.set_state(SpeedControllerState.WAITING_TO_STOP)
             case Label.TRAFFIC_LIGHT_GREEN:
+                self.stopped = False
                 self.controller.set_state(SpeedControllerState.DRIVING)
             case _:
                 pass

--- a/src/object_recognition/object_controller.py
+++ b/src/object_recognition/object_controller.py
@@ -43,6 +43,13 @@ class ObjectController:
 
             handler.handle(filtered_predictions)
 
+    def has_stopped(self) -> bool:
+        """Checks if the go-kart has stopped.
+
+        :return: Whether the go-kart has stopped.
+        """
+        return self.speed_controller.state == SpeedControllerState.STOPPED
+
     def set_max_speed(self, speed: int) -> None:
         """Sets the maximum speed of the go-kart.
 


### PR DESCRIPTION
- Adds a better `initialize_can` function:
  - Will use the vcan if can0 is not available.
  - Will log a warning stating the vcan is used (so we don't look for bugs another 20 minutes).
- Tracks the pedestrian based on the relative location to the crosswalk
  - This is to prevent the coordinates from changing too much as we are nearing.
  - Will continue to work when we randomly decide to steer.
- Adds a `stopped` attribute to all handlers that can stop the kart, ensuring we don't override another handler's decision.
- Uses a new system to calculate the safe zone.
  - Previously, we simply checked where the pedestrian was standing initially.
  - We now check for the second last known side, this acts as a fail-safe for the pedestrian crossing multiple times.