### PR TITLE
feat: move the calibration function to a script

### DIFF
--- a/configs/config.defaults.yaml
+++ b/configs/config.defaults.yaml
@@ -11,7 +11,7 @@ calibration:
   max_image_height: 1600
   max_image_width: 800
   marker_length: 0.070
-  save_dir: "../data/calibration"
+  save_dir: "../../data/calibration"
   square_length: 0.094
   vanishing_line_offset: 0.1
 

--- a/scripts/python/calibrate_cameras.py
+++ b/scripts/python/calibrate_cameras.py
@@ -1,0 +1,34 @@
+from config import config
+from constants import CameraResolution
+from lane_assist.preprocessing.calibrate import CameraCalibrator
+from utils.video_stream import VideoStream
+
+
+def calibrate_cameras() -> None:
+    """A script to calibrate the cameras."""
+    cam_left = VideoStream(config.camera_ids.left, resolution=CameraResolution.FHD)
+    cam_center = VideoStream(config.camera_ids.center, resolution=CameraResolution.FHD)
+    cam_right = VideoStream(config.camera_ids.right, resolution=CameraResolution.FHD)
+
+    cam_left.start()
+    cam_center.start()
+    cam_right.start()
+
+    if not cam_left.has_next() or not cam_center.has_next() or not cam_right.has_next():
+        raise ValueError("Could not capture images from cameras")
+
+    left_image = cam_left.next()
+    center_image = cam_center.next()
+    right_image = cam_right.next()
+
+    calibrator = CameraCalibrator([left_image, center_image, right_image], input_shape=(1280, 720))
+    calibrator.calibrate()
+    calibrator.save(config.calibration.save_dir)
+
+    cam_left.stop()
+    cam_center.stop()
+    cam_right.stop()
+
+
+if __name__ == "__main__":
+    calibrate_cameras()

--- a/src/main.py
+++ b/src/main.py
@@ -1,13 +1,12 @@
 import os
 
 from config import config
-from constants import Gear, CameraResolution
+from constants import Gear
 from driving.can import CANController, get_can_bus
 from driving.speed_controller import SpeedController, SpeedControllerState
 from lane_assist.helpers import td_stitched_image_generator
 from lane_assist.lane_assist import LaneAssist
 from lane_assist.line_following.path_follower import PathFollower
-from lane_assist.preprocessing.calibrate import CameraCalibrator
 from object_recognition.handlers.pedestrian_handler import PedestrianHandler
 from object_recognition.handlers.speed_limit_handler import SpeedLimitHandler
 from object_recognition.handlers.traffic_light_handler import TrafficLightHandler
@@ -17,32 +16,6 @@ from pathlib import Path
 from utils.calibration_data import CalibrationData
 from utils.video_stream import VideoStream
 from telemetry.app import TelemetryServer
-
-
-def calibrate_cameras() -> None:
-    """Example script to calibrate the cameras."""
-    cam_left = VideoStream(config.camera_ids.left, resolution=CameraResolution.FHD)
-    cam_center = VideoStream(config.camera_ids.center, resolution=CameraResolution.FHD)
-    cam_right = VideoStream(config.camera_ids.right, resolution=CameraResolution.FHD)
-
-    cam_left.start()
-    cam_center.start()
-    cam_right.start()
-
-    if not cam_left.has_next() or not cam_center.has_next() or not cam_right.has_next():
-        raise ValueError("Could not capture images from cameras")
-
-    left_image = cam_left.next()
-    center_image = cam_center.next()
-    right_image = cam_right.next()
-
-    calibrator = CameraCalibrator([left_image, center_image, right_image], input_shape=(1280, 720))
-    calibrator.calibrate()
-    calibrator.save(config.calibration.save_dir)
-
-    cam_left.stop()
-    cam_center.stop()
-    cam_right.stop()
 
 
 def start_kart() -> None:


### PR DESCRIPTION
It's not feasible to add a "Calibrate" button to the telemetry site. The calibration has to be run with the highest resolution available, we can only have one stream at a time, however. 

Simply moving the calibration function from main to a script seems like the best option for now. Still easy to use, but the downside is that we cannot see the result until we start the telemetry app.