### PR TITLE
fix: double .data

### DIFF
--- a/src/driving/can/can_controller.py
+++ b/src/driving/can/can_controller.py
@@ -93,6 +93,6 @@ class CANController(ICANController):
             message = self.bus.recv()
             if message.arbitration_id in self.__listeners:
                 for listener in self.__listeners[message.arbitration_id]:
-                    listener(message.data)
+                    listener(message)
 
             time.sleep(0)


### PR DESCRIPTION
Apparently, we had `.data` twice, now once. Should no longer crash