### PR TITLE
feat: reduce processing time of stitching images

### DIFF
--- a/src/calibration/utils/other.py
+++ b/src/calibration/utils/other.py
@@ -9,20 +9,7 @@ from src.config import config
 Coordinate = tuple[int, int] | np.ndarray
 
 
-def calculate_stitched_shape(offsets: np.ndarray, shapes: np.ndarray) -> tuple[int, int]:
-    """Calculate the output shape for the stitched image.
-
-    :param offsets: The offsets for the images.
-    :param shapes: The shapes of the images.
-    :return: The output shape for the stitched image (width, height).
-    """
-    width = max(shape[0] + offset[0] for shape, offset in zip(shapes, offsets))
-    height = max(shape[1] + offset[1] for shape, offset in zip(shapes, offsets))
-
-    return width, height
-
-
-def euclidean_distance(p1: np.ndarray | Coordinate, p2: np.ndarray | Coordinate) -> float:
+def euclidean_distance(p1: Coordinate, p2: Coordinate) -> float:
     """Calculate the Euclidean distance between two points.
 
     :param p1: The first point.


### PR DESCRIPTION
We now only keep the part of the stitched image that we actually use, almost cutting the amount of pixels to transform in half. Initial benchmarks show that it makes the whole process about 50% faster.