### PR TITLE
fix: add time.sleep to the overtake handler

### DIFF
--- a/configs/config.defaults.yaml
+++ b/configs/config.defaults.yaml
@@ -108,6 +108,10 @@ traffic_light:
 
 overtake:
   consecutive_frames: 3
+  force_return:
+    enabled: true
+    angle: 1.0  # percentage
+    duration: 0.5  # seconds
   min_distance: 6
   min_angle: 230
   max_angle: 280

--- a/src/driving/modes/autonomous.py
+++ b/src/driving/modes/autonomous.py
@@ -110,11 +110,15 @@ class AutonomousDriving(DrivingMode):
         object_controller.add_handler(SpeedLimitHandler(object_controller))
         object_controller.add_handler(TrafficLightHandler(object_controller))
 
+        # Initialize Lidar-specific handlers.
         lidar = Lidar.safe_init()
         if lidar is not None:
             object_controller.add_handler(OvertakeHandler(object_controller, lidar))
             object_controller.add_handler(ParkingHandler(object_controller, lidar))
 
+            lidar.start()
+
+        # Initialize the object detector.
         self.detector = ObjectDetector.from_model(
             config["object_detection"]["model_path"], object_controller, config["camera_ids"]["center"]
         )

--- a/src/object_recognition/object_controller.py
+++ b/src/object_recognition/object_controller.py
@@ -151,3 +151,10 @@ class ObjectController:
         :param state: The new state.
         """
         self.speed_controller.state = state
+
+    def set_steering(self, angle: float) -> None:
+        """Set the steering of the go-kart.
+
+        :param angle: The angle to set.
+        """
+        self.speed_controller.can_controller.set_steering(angle)


### PR DESCRIPTION
- Apparently OvertakeHandler did not have any `time.sleep`'s, causing the whole application to slow down.
- This also adds a new option to force steering back to the previous lane in case the line gets detected poorly or if a line has the wrong type.