### PR TITLE
feat: add --all flag & cleanup scripts

### DIFF
--- a/scripts/python/calibrate_cameras.py
+++ b/scripts/python/calibrate_cameras.py
@@ -58,12 +58,12 @@ def calibrate_cameras() -> None:
     center_image = cam_center.next()
     right_image = cam_right.next()
 
-    calibrate_images([left_image, center_image, right_image])
-
     # Stop the camera streams.
     cam_left.stop()
     cam_center.stop()
     cam_right.stop()
+
+    calibrate_images([left_image, center_image, right_image])
 
 
 if __name__ == "__main__":

--- a/scripts/python/data_driving.py
+++ b/scripts/python/data_driving.py
@@ -1,3 +1,4 @@
+import argparse
 import cv2
 import sys
 import time
@@ -13,8 +14,11 @@ from src.driving.modes import ManualDriving
 from src.utils.video_stream import VideoStream
 
 
-def start_collecting() -> None:
-    """Start collecting data."""
+def start_collecting(all_cameras: bool = False) -> None:
+    """Start collecting data.
+
+    :param all_cameras: Whether to use all available cameras (left, center, right).
+    """
     folder_name = datetime.now().strftime("%m_%d_%Y_%H_%M_%S")
     folder = Path("./data/images/" + folder_name)
     folder.mkdir(parents=True, exist_ok=True)
@@ -24,7 +28,16 @@ def start_collecting() -> None:
     center_cam = VideoStream(config["camera_ids"]["center"], resolution=CameraResolution.HD)
     center_cam.start()
 
-    if not center_cam.has_next():
+    left_cam = None
+    right_cam = None
+    if all_cameras:
+        left_cam = VideoStream(config["camera_ids"]["left"], resolution=CameraResolution.HD)
+        right_cam = VideoStream(config["camera_ids"]["right"], resolution=CameraResolution.HD)
+
+        left_cam.start()
+        right_cam.start()
+
+    if not center_cam.has_next() or (all_cameras and (not left_cam.has_next() or not right_cam.has_next())):
         raise ValueError("Could not capture images from cameras")
 
     print("Collecting data...", file=sys.stderr)  # noqa: T201
@@ -34,13 +47,23 @@ def start_collecting() -> None:
             timestamp = time.time_ns() // 1000000
             center_image = center_cam.next()
 
-            cv2.imwrite(str(folder / f"{timestamp}.jpg"), center_image)
+            cv2.imwrite(str(folder / f"{timestamp}_center.jpg"), center_image)
+
+            if all_cameras:
+                left_image = left_cam.next()
+                right_image = right_cam.next()
+
+                cv2.imwrite(str(folder / f"{timestamp}_left.jpg"), left_image)
+                cv2.imwrite(str(folder / f"{timestamp}_right.jpg"), right_image)
     except KeyboardInterrupt:
         pass
 
     print("Stopping...", file=sys.stderr)  # noqa: T201
 
     center_cam.stop()
+    if all_cameras:
+        left_cam.stop()
+        right_cam.stop()
 
 
 def start_driving() -> None:
@@ -56,11 +79,11 @@ def start_driving() -> None:
     controller.start()
 
 
-def main() -> None:
-    """Start the data acquisition."""
-    start_driving()
-    start_collecting()
-
-
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(description="Start collecting images while driving.")
+    parser.add_argument("--all", action="store_true", help="Use all available cameras (left, center, right).")
+
+    args = parser.parse_args()
+
+    start_driving()
+    start_collecting(args.all)

--- a/scripts/python/show_calibrated_cameras.py
+++ b/scripts/python/show_calibrated_cameras.py
@@ -3,8 +3,6 @@ import logging
 import numpy as np
 import requests
 
-from pathlib import Path
-
 from src.calibration.data import CalibrationData
 from src.config import config
 from src.constants import CameraResolution
@@ -42,11 +40,7 @@ def send_discord_calibration() -> None:
     center_image = cv2.cvtColor(center_image, cv2.COLOR_BGR2GRAY)
     right_image = cv2.cvtColor(right_image, cv2.COLOR_BGR2GRAY)
 
-    calibration_path = Path(config["calibration"]["calibration_file"])
-    if not calibration_path.exists():
-        raise FileNotFoundError(f"Calibration file not found: {calibration_path}")
-
-    calibration_data = CalibrationData.load(calibration_path)
+    calibration_data = CalibrationData.load(config["calibration"]["calibration_file"])
     topdown = calibration_data.transform([left_image, center_image, right_image])
 
     try:


### PR DESCRIPTION
- Adds a `--all` flag to `data_driving.py` so we can collect images from all 3 cameras.
- Removes redundant code from `show_calibrated_cameras.py`.
- Stop the camera streams before actually calibrating the images.
  - This will prevent `show_calibrated_cameras` from having the wrong resolution.